### PR TITLE
Fix debounce logic for lap detection

### DIFF
--- a/MathUtils.h
+++ b/MathUtils.h
@@ -180,13 +180,7 @@ public:
         if (bearing_diff > 90.0)
             return false; // Пересечение не в ту сторону
 
-        // Дебаунсинг на основе millis() - предотвращает многократные срабатывания на одной линии
-        unsigned long now_millis_debounce = millis();
-        if (now_millis_debounce - lastCrossMillis < (minLapTimeMs / 4)) { // Уменьшил время дебаунсинга
-            // Serial.println("Debounced cross");
-            return false;
-        }
-        lastCrossMillis = now_millis_debounce;
+        // Проверка на пересечение выполнена и направление корректно
         return true;
     }
 };

--- a/TrackingState.cpp
+++ b/TrackingState.cpp
@@ -25,7 +25,8 @@ void TrackingState::loop(unsigned long) {
         if (dt >= 10 && dt <= 1000) {
             FullNmeaTime crossTime = MathUtils::add_ms_to_nmea_time(lc.prevFixNmeaTime_G, long(tRatio * dt));
             unsigned long lapTime = MathUtils::calculate_lap_duration_ms(crossTime, lc.lapStartNmeaTime_G);
-            if (lapTime >= MathUtils::minLapTimeMs) {
+            if (lapTime >= MathUtils::minLapTimeMs &&
+                millis() - MathUtils::lastCrossMillis >= MathUtils::minLapTimeMs / 4) {
                 lc.lastLapTime = lapTime;
                 if (lc.bestLapTime == 0 || lapTime < lc.bestLapTime) {
                     lc.bestLapTime = lapTime;
@@ -37,6 +38,7 @@ void TrackingState::loop(unsigned long) {
                     }
                 }
                 lc.lapStartNmeaTime_G = crossTime;
+                MathUtils::lastCrossMillis = millis();
             }
         }
     }

--- a/WaitLapStartState.cpp
+++ b/WaitLapStartState.cpp
@@ -30,11 +30,14 @@ void WaitLapStartState::loop(unsigned long)
         Logger::log("loop crossedLineInterpolated");
         long dt = MathUtils::calculate_nmea_fix_interval_ms(data.nmeaTime, lc.prevFixNmeaTime_G);
         if (dt >= 10 && dt <= 1000) {
-            lc.lapStartNmeaTime_G = MathUtils::add_ms_to_nmea_time(lc.prevFixNmeaTime_G, long(tRatio * dt));
-            lc.lapStartNmeaTime_G.isValid = true;
-            lc.lapStarted = true;
-            Logger::log("loop LOGIC_TRACKING");
-            stateMachine.setState(LOGIC_TRACKING);
+            if (millis() - MathUtils::lastCrossMillis >= MathUtils::minLapTimeMs / 4) {
+                lc.lapStartNmeaTime_G = MathUtils::add_ms_to_nmea_time(lc.prevFixNmeaTime_G, long(tRatio * dt));
+                lc.lapStartNmeaTime_G.isValid = true;
+                lc.lapStarted = true;
+                MathUtils::lastCrossMillis = millis();
+                Logger::log("loop LOGIC_TRACKING");
+                stateMachine.setState(LOGIC_TRACKING);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove debounce timing update from `MathUtils::crossedLineInterpolated`
- apply debounce check when starting a lap and when recording a lap

## Testing
- `arduino-cli compile` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684025b41eac832a8bb578f9c7130114